### PR TITLE
setting up "bower install" in "postinstall" hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ In order to modify these assets you need to install the following:
 
 * the [Development Edition of Pattern Lab PHP](https://github.com/pattern-lab/edition-php-development)
 * [Node.js](http://nodejs.org) and NPM
-* [Bower](http://bower.io)
 * [Ruby Sass](http://sass-lang.com/install)
 	
 ## Development Set-up
@@ -23,8 +22,7 @@ Once you've installed the requirements do the following to set-up for developmen
 
 1. `cd /path/to/dev-edition/packages/pattern-lab/styleguidekit-assets-default`
 2. `git config branch.dev.remote origin`
-3. `npm install`
-4. `bower install`
+3. `npm install` (`bower install` is run automatically afterwards)
 
 ## Making Changes
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "url": "https://github.com/pattern-lab/styleguidekit-assets-default/issues"
   },
   "homepage": "https://github.com/pattern-lab/styleguidekit-assets-default",
+  "scripts": {
+    "postinstall": "bower install"
+  },
   "devDependencies": {
+    "bower": "^1.7.9",
     "del": "^1.1.1",
     "gulp": "^3.8.6",
     "gulp-autoprefixer": "^2.1",


### PR DESCRIPTION
With these changes, `bower install` is ran automatically after `npm install` so it's not forgotten and `bower` does not need to be globally installed before (no need to `npm install --global bower`) as all `scripts` from `package.json` have all dependencies added to their `$PATH` (which just reside in `./node_modules/.bin/`). 
