### PR TITLE
rendering code description html (`master` branch)

### DIFF
--- a/dist/html/index.html
+++ b/dist/html/index.html
@@ -155,7 +155,10 @@
 			</p>
 		</div>
 		{{/ lineageRExists }}
-		{{ patternDesc }}
+		<!-- @todo Add `patternDescExists` conditional -->
+		<div id="sg-code-desc">
+			{{{ patternDesc }}}
+		</div>
 		{{# patternDescAdditions }}
 			{{{ . }}}
 		{{/ patternDescAdditions }}

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -155,7 +155,10 @@
 			</p>
 		</div>
 		{{/ lineageRExists }}
-		{{ patternDesc }}
+		<!-- @todo Add `patternDescExists` conditional -->
+		<div id="sg-code-desc">
+			{{{ patternDesc }}}
+		</div>
 		{{# patternDescAdditions }}
 			{{{ . }}}
 		{{/ patternDescAdditions }}


### PR DESCRIPTION
When I use Pattern Description files (i.e. `pattern.md`), the HTML code is escaped and is not rendered in the "code" view. This renders that HTML in the code slide up. I tried these two conditional wrappers with no success:

``` html
{{# patternDescExists}}
  <div id="sg-code-desc">
    {{{ patternDesc }}}
  </div>
{{/ patternDescExists}}
```

and:

``` html
{{# patternDesc}}
  <div id="sg-code-desc">
    {{{ patternDesc }}}
  </div>
{{/ patternDesc}}
```
