### PR TITLE
Prefer the display of a pattern's engine name in the template tab

### DIFF
--- a/src/js/panels-viewer.js
+++ b/src/js/panels-viewer.js
@@ -60,7 +60,7 @@ var panelsViewer = {
       
       // catch pattern panel since it doesn't have a name defined by default
       if (panel.name === undefined) {
-        panel.name = patternData.patternExtension;
+        panel.name = patternData.patternEngineName || patternData.patternExtension;
         panel.httpRequestReplace = panel.httpRequestReplace+'.'+patternData.patternExtension;
         panel.language = patternData.patternExtension;
       }


### PR DESCRIPTION
Use `patternEngineName` if it's present in the patternData block, otherwise stick with `patternExtension`.

Addresses #43.
Matching change to the Node version is in https://github.com/pattern-lab/patternlab-node/pull/447.
