### PR TITLE
Fix JS errors when "Open in new window" menu is hidden

### DIFF
--- a/src/js/styleguide.js
+++ b/src/js/styleguide.js
@@ -517,7 +517,7 @@
     history.replaceState({ "pattern": patternName }, null, null);
   }
 
-  if (document.getElementById("sg-raw") !== undefined) {
+  if (document.getElementById("sg-raw") !== null) {
     document.getElementById("sg-raw").setAttribute("href",urlHandler.getFileName(patternName));
   }
 

--- a/src/js/url-handler.js
+++ b/src/js/url-handler.js
@@ -153,7 +153,7 @@ var urlHandler = {
         history.pushState(data, null, addressReplacement);
       }
       document.getElementById("title").innerHTML = "Pattern Lab - "+pattern;
-      if (document.getElementById("sg-raw") !== undefined) {
+      if (document.getElementById("sg-raw") !== null) {
         document.getElementById("sg-raw").setAttribute("href",urlHandler.getFileName(pattern));
       }
     }
@@ -184,7 +184,9 @@ var urlHandler = {
     var obj = JSON.stringify({ "event": "patternLab.updatePath", "path": iFramePath });
     document.getElementById("sg-viewport").contentWindow.postMessage( obj, urlHandler.targetOrigin);
     document.getElementById("title").innerHTML = "Pattern Lab - "+patternName;
-    document.getElementById("sg-raw").setAttribute("href",urlHandler.getFileName(patternName));
+    if (document.getElementById("sg-raw") !== null) {
+      document.getElementById("sg-raw").setAttribute("href",urlHandler.getFileName(patternName));
+    }
     
     /*
     if (wsnConnected !== undefined) {


### PR DESCRIPTION
Setting the `ishControlsHide.views-new` flag to `true` (thereby hiding the "Open in new window" menu item) would cause JS errors in the browser. The JS was trying to manipulate the `#sg-raw` element, which isn't there.

Fixes:
- In two places, checks for the nonexistence of the menu item were in place, but checking against the wrong value (`document.getElementById()` returns `null` when no results, not `undefined`). Corrected.
- In one place, the check was missing. Added.
