### PR TITLE
Hide "All" button if JSON flag is set

### DIFF
--- a/src/html/partials/pattern-nav.html
+++ b/src/html/partials/pattern-nav.html
@@ -12,4 +12,6 @@
   {{/ patternItems }}
   </ol></li>
 {{/ patternTypes }}
-<li><a href="styleguide/html/styleguide.html" class="sg-pop" data-patternpartial="all">All</a></li>
+{{^ ishControlsHide.views-all }}
+  <li><a href="styleguide/html/styleguide.html" class="sg-pop" data-patternpartial="all">All</a></li>
+{{/ ishControlsHide.views-all }}


### PR DESCRIPTION
This adds a conditional in the nav template that will hide the "All" button if the `ishControlsHide.views-all` flag is set. Previously, this option existed, but was not used anywhere.

Relies on a pattern-lab/patternlab-node#547 that passes this option to the template.
