### PR TITLE
add allow-modals to iframe sandbox

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -37,7 +37,7 @@
 
     <div class="pl-c-viewport__iframe-wrapper pl-js-vp-iframe-container">
         
-        <iframe class="pl-c-viewport__iframe pl-js-iframe" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>
+        <iframe class="pl-c-viewport__iframe pl-js-iframe" sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals"></iframe>
         
         <div class="pl-c-viewport__resizer pl-js-resize-container">
 

--- a/src/html/partials/iframe.html
+++ b/src/html/partials/iframe.html
@@ -4,7 +4,7 @@
 
     <div class="pl-c-viewport__iframe-wrapper pl-js-vp-iframe-container">
         
-        <iframe class="pl-c-viewport__iframe pl-js-iframe" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>
+        <iframe class="pl-c-viewport__iframe pl-js-iframe" sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals"></iframe>
         
         <div class="pl-c-viewport__resizer pl-js-resize-container">
 


### PR DESCRIPTION
To allow for components to use alert and confirm dialogs, the sandbox needs to allow-modals.
Could you add this?