### PR TITLE
Taking theme config and applying classes desired. 

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -342,6 +342,31 @@
 
 	<!-- load Pattern Lab data -->
 	<script src="styleguide/data/patternlab-data.js"></script>
+
+  <!-- applying theme config to get classes on before PL renders so there's no flash of unstyled content -->
+  <!-- @todo Consider moving this to own file -->
+  <script>
+    if (config && config.theme) {
+      if (config.theme.color === 'light') {
+        document.body.classList.add('pl-c-body--theme-light');
+      }
+      if (config.theme.layout === 'vertical') {
+        document.body.classList.add('pl-c-body--theme-sidebar');
+      }
+      switch (config.theme.density) {
+        case 'cozy':
+          document.body.classList.add('pl-c-body--theme-density-cozy');
+          break;
+        case 'comfortable':
+          document.body.classList.add('pl-c-body--theme-density-comfortable');
+          break;
+        default:
+          // not sure if you even need/want this
+          document.body.classList.add('pl-c-body--theme-density-compact');
+      }
+    }
+  </script>
+
 	<script src="annotations/annotations.js"></script>
 
 	<!-- load Pattern Lab external library js -->

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -37,6 +37,31 @@
 
 	<!-- load Pattern Lab data -->
 	<script src="styleguide/data/patternlab-data.js"></script>
+
+  <!-- applying theme config to get classes on before PL renders so there's no flash of unstyled content -->
+  <!-- @todo Consider moving this to own file -->
+  <script>
+    if (config && config.theme) {
+      if (config.theme.color === 'light') {
+        document.body.classList.add('pl-c-body--theme-light');
+      }
+      if (config.theme.layout === 'vertical') {
+        document.body.classList.add('pl-c-body--theme-sidebar');
+      }
+      switch (config.theme.density) {
+        case 'cozy':
+          document.body.classList.add('pl-c-body--theme-density-cozy');
+          break;
+        case 'comfortable':
+          document.body.classList.add('pl-c-body--theme-density-comfortable');
+          break;
+        default:
+          // not sure if you even need/want this
+          document.body.classList.add('pl-c-body--theme-density-compact');
+      }
+    }
+  </script>
+
 	<script src="annotations/annotations.js"></script>
 
 	<!-- load Pattern Lab external library js -->


### PR DESCRIPTION
This is a very basic implementation of what's discussed in #91 and I'm very open to refactoring. However, this gets the job done, has no flash of unsettled content as it's render blocking JS that requires no dependencies (works in IE10+), and will be very easy for @bradfrost to alter config settings in PL's config and apply that to the classes he'd like wherever.

I tested and saw the light theme, but didn't see the other options - I might be missing some of your work on the branches I pulled down though.