### PR TITLE
Make better use of the viewportResizeHandleWidth variable in JS

### DIFF
--- a/src/js/styleguide.js
+++ b/src/js/styleguide.js
@@ -372,7 +372,7 @@
 	//Update The viewport size
 	function updateViewportWidth(size) {
 		$(".pl-js-iframe").width(size);
-		$(".pl-js-vp-iframe-container").width(size * 1 + 14);
+		$(".pl-js-vp-iframe-container").width(size * 1 + viewportResizeHandleWidth);
 
 		updateSizeReading(size);
 	}
@@ -434,7 +434,7 @@
 	if (($(window).width() == testWidth) && ('ontouchstart' in document.documentElement) && ($(window).width() <= 1024)) {
 		$(".pl-js-resize-container").width(0);
 	} else {
-		$(".pl-js-iframe").width(origViewportWidth - 14);
+		$(".pl-js-iframe").width(origViewportWidth - viewportResizeHandleWidth);
 	}
 	updateSizeReading($(".pl-js-iframe").width());
 


### PR DESCRIPTION
Just a small cleanup PR to avoid magic numbers in the code.

Several places in this file use the `viewportResizeHandleWidth` variable when calculating widths. I found `14` being used in two places where it appears that the variable should have been used.