### PR TITLE
Use shared jQuery references instead of repeately querying DOM

### DIFF
--- a/src/js/styleguide.js
+++ b/src/js/styleguide.js
@@ -27,6 +27,7 @@
 		}
 	
 		var viewportResizeHandleWidth = 14, //Width of the viewport drag-to-resize handle
+		$sgIframeContainer = $('.pl-js-vp-iframe-container'), //Outer container for viewport
 		$sgIframe = $('.pl-js-iframe'), //Viewport element
 		$sizePx = $('#pl-size-px'), //Px size input element in toolbar
 		$sizeEms = $('#pl-size-em'), //Em size input element in toolbar
@@ -315,7 +316,7 @@
 			"event": "patternLab.resize",
 			"resize": "true"
 		});
-		document.querySelector('.pl-js-iframe').contentWindow.postMessage(obj, targetOrigin);
+		$sgIframe.get(0).contentWindow.postMessage(obj, targetOrigin);
 
 		updateSizeReading(theSize); //Update values in toolbar
 		saveSize(theSize); //Save current viewport to cookie
@@ -327,7 +328,7 @@
 			"event": "patternLab.resize",
 			"resize": "true"
 		});
-		document.querySelector('.pl-js-iframe').contentWindow.postMessage(obj, targetOrigin);
+		$sgIframe.get(0).contentWindow.postMessage(obj, targetOrigin);
 	});
 
 	function saveSize(size) {
@@ -371,7 +372,7 @@
 
 	//Update The viewport size
 	function updateViewportWidth(size) {
-		$(".pl-js-iframe").width(size);
+		$sgIframe.width(size);
 		$(".pl-js-vp-iframe-container").width(size * 1 + 14);
 
 		updateSizeReading(size);
@@ -424,7 +425,7 @@
 
 
 	// capture the viewport width that was loaded and modify it so it fits with the pull bar
-	var origViewportWidth = $(".pl-js-iframe").width();
+	var origViewportWidth = $sgIframe.width();
 	$(".pl-js-vp-iframe-container").width(origViewportWidth);
 
 	var testWidth = screen.width;
@@ -434,9 +435,9 @@
 	if (($(window).width() == testWidth) && ('ontouchstart' in document.documentElement) && ($(window).width() <= 1024)) {
 		$(".pl-js-resize-container").width(0);
 	} else {
-		$(".pl-js-iframe").width(origViewportWidth - 14);
+		$sgIframe.width(origViewportWidth - 14);
 	}
-	updateSizeReading($(".pl-js-iframe").width());
+	updateSizeReading($sgIframe.width());
 
 	// get the request vars
 	var oGetVars = urlHandler.getRequestVars();
@@ -482,7 +483,7 @@
 	}
 
 	urlHandler.skipBack = true;
-	document.querySelector('.pl-js-iframe').contentWindow.location.replace(iFramePath);
+	$sgIframe.get(0).contentWindow.location.replace(iFramePath);
 
 	// Close all dropdowns and navigation
 	function closePanels() {
@@ -499,7 +500,7 @@
 			"event": "patternLab.updatePath",
 			"path": urlHandler.getFileName($(this).attr("data-patternpartial"))
 		});
-		document.querySelector('.pl-js-iframe').contentWindow.postMessage(obj, urlHandler.targetOrigin);
+		$sgIframe.get(0).contentWindow.postMessage(obj, urlHandler.targetOrigin);
 		closePanels();
 	});
 
@@ -514,7 +515,7 @@
 		window.addEventListener("orientationchange", function () {
 			if (window.orientation != origOrientation) {
 				$(".pl-js-vp-iframe-container").width($(window).width());
-				$(".pl-js-iframe").width($(window).width());
+				$sgIframe.width($(window).width());
 				updateSizeReading($(window).width());
 				origOrientation = window.orientation;
 			}

--- a/src/js/styleguide.js
+++ b/src/js/styleguide.js
@@ -29,6 +29,7 @@
 		var viewportResizeHandleWidth = 14, //Width of the viewport drag-to-resize handle
 		$sgIframeContainer = $('.pl-js-vp-iframe-container'), //Outer container for viewport
 		$sgIframe = $('.pl-js-iframe'), //Viewport element
+		$sgViewportCover = $('.pl-js-viewport-cover'), //Viewport cover element
 		$sizePx = $('#pl-size-px'), //Px size input element in toolbar
 		$sizeEms = $('#pl-size-em'), //Em size input element in toolbar
 		$bodySize = (config.ishFontSize !== undefined) ? parseInt(config.ishFontSize) : parseInt($('body').css('font-size')), //Body size of the document
@@ -207,18 +208,18 @@
 		var currentWidth = $sgIframe.width();
 		hayMode = false;
 		$sgIframe.removeClass('hay-mode');
-		$('.pl-js-vp-iframe-container').removeClass('hay-mode');
+		$sgIframeContainer.removeClass('hay-mode');
 		sizeiframe(Math.floor(currentWidth));
 	}
 
 	// start Hay! mode
 	function startHay() {
 		hayMode = true;
-		$('.pl-js-vp-iframe-container').removeClass("vp-animate").width(minViewportWidth + viewportResizeHandleWidth);
+		$sgIframeContainer.removeClass("vp-animate").width(minViewportWidth + viewportResizeHandleWidth);
 		$sgIframe.removeClass("vp-animate").width(minViewportWidth);
 
 		var timeoutID = window.setTimeout(function () {
-			$('.pl-js-vp-iframe-container').addClass('hay-mode').width(maxViewportWidth + viewportResizeHandleWidth);
+			$sgIframeContainer.addClass('hay-mode').width(maxViewportWidth + viewportResizeHandleWidth);
 			$sgIframe.addClass('hay-mode').width(maxViewportWidth);
 
 			setInterval(function () {
@@ -303,12 +304,12 @@
 
 		//Conditionally remove CSS animation class from viewport
 		if (animate === false) {
-			$('.pl-js-vp-iframe-container, .pl-js-iframe').removeClass("vp-animate"); //If aninate is set to false, remove animate class from viewport
+			$sgIframe.add($sgIframeContainer).removeClass("vp-animate"); //If aninate is set to false, remove animate class from viewport
 		} else {
-			$('.pl-js-vp-iframe-container, .pl-js-iframe').addClass("vp-animate");
+			$sgIframe.add($sgIframeContainer).addClass("vp-animate");
 		}
 
-		$('.pl-js-vp-iframe-container').width(theSize + viewportResizeHandleWidth); //Resize viewport wrapper to desired size + size of drag resize handler
+		$sgIframeContainer.width(theSize + viewportResizeHandleWidth); //Resize viewport wrapper to desired size + size of drag resize handler
 		$sgIframe.width(theSize); //Resize viewport to desired size
 
 		var targetOrigin = (window.location.protocol === "file:") ? "*" : window.location.protocol + "//" + window.location.host;
@@ -322,7 +323,7 @@
 		saveSize(theSize); //Save current viewport to cookie
 	}
 
-	$(".pl-js-vp-iframe-container").on('transitionend webkitTransitionEnd', function (e) {
+	$sgIframeContainer.on('transitionend webkitTransitionEnd', function (e) {
 		var targetOrigin = (window.location.protocol === "file:") ? "*" : window.location.protocol + "//" + window.location.host;
 		var obj = JSON.stringify({
 			"event": "patternLab.resize",
@@ -373,12 +374,12 @@
 	//Update The viewport size
 	function updateViewportWidth(size) {
 		$sgIframe.width(size);
-		$(".pl-js-vp-iframe-container").width(size * 1 + 14);
+		$sgIframeContainer.width(size * 1 + 14);
 
 		updateSizeReading(size);
 	}
 
-	$('.pl-js-vp-iframe-container').on('touchstart', function (event) {});
+	$sgIframeContainer.on('touchstart', function (event) {});
 
 	// handles widening the "viewport"
 	//   1. on "mousedown" store the click location
@@ -393,10 +394,10 @@
 		fullMode = false;
 
 		// show the cover
-		$(".pl-js-viewport-cover").css("display", "block");
+		$sgViewportCover.css("display", "block");
 
 		// add the mouse move event and capture data. also update the viewport width
-		$('.pl-js-viewport-cover').mousemove(function (event) {
+		$sgViewportCover.mousemove(function (event) {
 			var viewportWidth;
 
 			viewportWidth = origViewportWidth + 2 * (event.clientX - origClientX);
@@ -419,14 +420,14 @@
 
 	// on "mouseup" we unbind the "mousemove" event and hide the cover again
 	$('body').mouseup(function () {
-		$('.pl-js-viewport-cover').unbind('mousemove');
-		$('.pl-js-viewport-cover').css("display", "none");
+		$sgViewportCover.unbind('mousemove');
+		$sgViewportCover.css("display", "none");
 	});
 
 
 	// capture the viewport width that was loaded and modify it so it fits with the pull bar
 	var origViewportWidth = $sgIframe.width();
-	$(".pl-js-vp-iframe-container").width(origViewportWidth);
+	$sgIframeContainer.width(origViewportWidth);
 
 	var testWidth = screen.width;
 	if (window.orientation !== undefined) {
@@ -514,7 +515,7 @@
 		var origOrientation = window.orientation;
 		window.addEventListener("orientationchange", function () {
 			if (window.orientation != origOrientation) {
-				$(".pl-js-vp-iframe-container").width($(window).width());
+				$sgIframeContainer.width($(window).width());
 				$sgIframe.width($(window).width());
 				updateSizeReading($(window).width());
 				origOrientation = window.orientation;


### PR DESCRIPTION
This change aims to improve readability and efficiency by reducing repeated DOM and/or jQuery selectors I found in `styleguide.js`.

- Make more use of an existing reference, `$sgIframe`
- Create two new references, `$sgIframeContainer` and `$sgViewportCover` and replace queries with them.

In cases where an instance of the repeated query was a jQuery selector, simply use the earlier-defined jQuery reference. In cases where a native `document.querySelector()` is used, I call jQuery's `.get(0)`, which pulls out the native DOM element from the reference. In either case, the DOM shouldn't have to be searched again for the same elements over and over.

I particularly focused on making these replacements in connection with the `mousemove` event while dragging the iframe handle, which can potentially be triggered many times per second.