### PR TITLE
allow-modals on iframe in release/3.x

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -36,7 +36,7 @@
     <div id="sg-vp-wrap">
       <div id="sg-cover"></div>
       <div id="sg-gen-container">
-        <iframe id="sg-viewport" name="sg-viewport" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>
+        <iframe id="sg-viewport" name="sg-viewport" sandbox="allow-same-origin allow-scripts allow-popups allow-modals allow-forms"></iframe>
         <div id="sg-rightpull-container">
           <div id="sg-rightpull"></div>
         </div>


### PR DESCRIPTION
This will allow popups to leave the iframe in v3 of `styleguidekit-assets-default` since there is no `styleguide-twig-default` to yet references v4 of `styleguidekit-assets-default`.